### PR TITLE
Remove compilation warnings

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -9,11 +9,11 @@ defmodule Mixpanel.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps,
+     deps: deps(),
 
      # Hex
-     description: description,
-     package: package,
+     description: description(),
+     package: package(),
 
      # Docs
      name: "Mixpanel API",


### PR DESCRIPTION
This PR removes the following warnings

```
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /Users/Me/Project/src/deps/mixpanel_api_ex/mix.exs:12

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /Users/Me/Project/src/deps/mixpanel_api_ex/mix.exs:15

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /Users/Me/Project/src/deps/mixpanel_api_ex/mix.exs:16
```