### PR TITLE
Not running the actual client when active config is set to false

### DIFF
--- a/lib/mixpanel/supervisor.ex
+++ b/lib/mixpanel/supervisor.ex
@@ -13,13 +13,12 @@ defmodule Mixpanel.Supervisor do
   def init(:ok) do
     config = Application.get_env(:mixpanel_api_ex, :config)
 
-    if config[:token] == nil do
-      raise "Please set :mixpanel, :token in your app environment's config"
+    children = if config[:active] do
+      if config[:token] == nil, do: raise "Please set :mixpanel, :token in your app environment's config"
+      [worker(Mixpanel.Client, [config, [name: Mixpanel.Client]])]
+    else
+      []
     end
-
-    children = [
-      worker(Mixpanel.Client, [config, [name: Mixpanel.Client]])
-    ]
 
     supervise(children, strategy: :one_for_one, name: Mixpanel.Supervisor)
   end


### PR DESCRIPTION
This PR might look like backwards incompatible, but as `GenServer.cast` always return `:ok`, the final result is the same for when the actual process is there or not. All in all, I think starting the process to actually not do anything is a useless spend of resources + I need it to not be started, cause I'm  trying to start `Mixpanel.Client` with custom config myself, as I want the token to be loaded at my system startup.